### PR TITLE
Add rack identifier to steps

### DIFF
--- a/adin_api/DTOs/StepDTO.cs
+++ b/adin_api/DTOs/StepDTO.cs
@@ -16,6 +16,8 @@ namespace adin_api.DTOs
         [Required]
         public string Instructions { get; set; }
 
+        public int? RackId { get; set; }
+
         [Required]
         public int TaskId { get; set; }
 

--- a/adin_api/Data/Models/Step.cs
+++ b/adin_api/Data/Models/Step.cs
@@ -17,6 +17,9 @@ namespace adin_api.Data.Models
         [Column("instructions", TypeName = "VARCHAR(1000)")]
         public string Instructions { get; set; }
 
+        [Column("rack_id")]
+        public int? RackId { get; set; }
+
         [Column("task_id")]
         public int TaskId { get; set; }
         public Task Task { get; set; }

--- a/adin_api/Migrations/20240519120000_AddRackIdToStep.cs
+++ b/adin_api/Migrations/20240519120000_AddRackIdToStep.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using adin_api.Data;
+
+namespace adin_api.Migrations
+{
+    [DbContext(typeof(DatabaseContext))]
+    [Migration("20240519120000_AddRackIdToStep")]
+    public partial class AddRackIdToStep : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "rack_id",
+                table: "Steps",
+                type: "integer",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "rack_id",
+                table: "Steps");
+        }
+    }
+}

--- a/adin_api/Migrations/DatabaseContextModelSnapshot.cs
+++ b/adin_api/Migrations/DatabaseContextModelSnapshot.cs
@@ -377,6 +377,10 @@ namespace adin_api.Migrations
                         .HasColumnType("integer")
                         .HasColumnName("step_number");
 
+                    b.Property<int?>("RackId")
+                        .HasColumnType("integer")
+                        .HasColumnName("rack_id");
+
                     b.Property<int>("TaskId")
                         .HasColumnType("integer")
                         .HasColumnName("task_id");


### PR DESCRIPTION
## Summary
- add nullable rack ID to step entity and DTOs
- migrate database to store rack IDs in steps

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ba4cc7b0832e82bc5afcb9da8565